### PR TITLE
Adjusted image size for mobile screens

### DIFF
--- a/src/bio/bio.scss
+++ b/src/bio/bio.scss
@@ -1,0 +1,8 @@
+.bio-image {
+    @media only screen and (max-width: 480px) {
+        width: 100%;
+    }
+    @media only screen and (min-width: 480px) {
+        width: 400px;
+    }
+}

--- a/src/bio/bio.tsx
+++ b/src/bio/bio.tsx
@@ -3,12 +3,14 @@ import Container from '@material-ui/core/Container';
 import { Paper, Box } from '@material-ui/core';
 import { ASSETS_PATH } from '../assets/constants';
 
+import './bio.scss';
+
 export const Bio: React.FC = () => {
   const imageSrc = `${ASSETS_PATH}/bio.jpg`;
   return (
     <Container maxWidth="md" className="Bio-container">
       <Box component={Paper} p={2}>
-        <img src={imageSrc} alt="Bio" width="400px" />
+        <img src={imageSrc} alt="Bio" className="bio-image" />
         <p>
           Meruyert Tulenova was born in Almaty, Kazakhstan. She started her
           musical education at the age of six at the Akhmet Jubanov School of


### PR DESCRIPTION
Fixed bio image for mobile screens.
Previous `400px` image was too large for smaller screens.

| Before | After |
| ------- | ----- |
| <img width="323" alt="before" src="https://user-images.githubusercontent.com/90318734/138760663-627c3a34-071d-43ee-ba30-f39d928743da.png"> | <img width="322" alt="after" src="https://user-images.githubusercontent.com/90318734/138760675-af367a8f-0e35-45ac-8e8d-74297dbd88f8.png"> |